### PR TITLE
Add test setup and document Python requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## セットアップ
 1. `.env.template` を `.env` にコピーして必要な値を設定します。
-2. Python 仮想環境 `.venv` を作成して有効化し、`faster-whisper` など必要なパッケージをインストールします。
+2. Python 仮想環境 `.venv` を作成して有効化し、`pip install -r requirements.txt` で依存パッケージをインストールします。
 3. 初回は `./run.sh --install` で Node.js と Python の依存関係をインストールします。
 4. ボットを起動するには `./run.sh` を実行します。
 

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { PassThrough } from 'node:stream';
 import ffmpegPath from 'ffmpeg-static';
+import { normalizeText } from './normalizeText.js';
 
 const token = (process.env.DISCORD_TOKEN ?? '').trim();
 if (!token || token.split('.').length !== 3) {
@@ -420,14 +421,6 @@ async function probeDuration(file, chunkId) {
   return null;
 }
 
-function normalizeText(s) {
-  if (!s) return '';
-  return s
-    .replace(/[\s\u3000]+/g, ' ')
-    .replace(/[。、．，・!！?？…—\-\(\)\[\]{}"'「」『』:：;；、｡､・〜~^]/g, '')
-    .trim()
-    .toLowerCase();
-}
 
 // 安全にWAV削除
 function safeDeleteWav(wavPath, chunkId, reason) {

--- a/normalizeText.js
+++ b/normalizeText.js
@@ -1,0 +1,8 @@
+export function normalizeText(s) {
+  if (!s) return '';
+  return s
+    .replace(/[\s\u3000]+/g, ' ')
+    .replace(/[。、．，・!！?？…—\-\(\)\[\]{}"'「」『』:：;；、｡､・〜~^]/g, '')
+    .trim()
+    .toLowerCase();
+}

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "name": "discord-recorder",
   "version": "1.0.0",
-  "description": "",
+  "description": "Discord bot that records voice chats and transcribes with Whisper",
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test",
     "start": "node index.js"
   },
   "keywords": [],
-  "author": "",
+  "author": "Discord STT Developers",
   "license": "ISC",
   "dependencies": {
     "@discordjs/opus": "^0.10.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+faster-whisper>=1.0.0

--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,7 @@
 # 使い方:
 #   chmod +x run.sh
 #   ./run.sh            # 起動
-#   ./run.sh --install  # 依存を自動インストール（npm/pip）
+#   ./run.sh --install  # 依存を自動インストール（npm/pip install -r requirements.txt）
 
 set -euo pipefail
 

--- a/test/normalizeText.test.js
+++ b/test/normalizeText.test.js
@@ -1,0 +1,8 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { normalizeText } from '../normalizeText.js';
+
+test('normalizeText removes punctuation and trims spaces', () => {
+  const result = normalizeText('  Hello，World！  ');
+  assert.strictEqual(result, 'helloworld');
+});


### PR DESCRIPTION
## Summary
- Fill in package metadata and run tests with Node's built-in runner
- Factor out `normalizeText` utility and cover it with a unit test
- Document Python dependency in `requirements.txt` and mention it in setup script and README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9d65f2670832c866579a71e382c44