### PR TITLE
Remove processed audio files after transcription

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ const logStream = fs.createWriteStream(LOG_FILE, { flags: 'a' });
 process.on('exit', () => logStream.end());
 
 // ★ 削除ポリシー
-const DELETE_WAV = process.env.DELETE_WAV === '1';                 // STT後にWAV削除
+const DELETE_WAV = process.env.DELETE_WAV === '1';                 // スキップ/エラー時にWAV削除 (STT成功時はstt.pyが削除)
 const DELETE_WAV_ON_SKIP = (process.env.DELETE_WAV_ON_SKIP ?? '1') === '1'; // スキップ時も削除
 const KEEP_WAV_ON_ERROR = (process.env.KEEP_WAV_ON_ERROR ?? '1') === '1';   // エラー時は保持
 
@@ -323,8 +323,7 @@ async function runNextSTT() {
       log('warn', 'no channelId; skipping post', { chunkId });
     }
 
-    // ★ STT成功（投稿の成否は問わず）→ WAV削除
-    if (DELETE_WAV) safeDeleteWav(file, chunkId, 'stt-done');
+    // ★ STT成功時のWAV削除は stt.py で実施
 
   } catch (e) {
     log('error', 'STT job failed', { chunkId, err: String(e) });

--- a/stt.py
+++ b/stt.py
@@ -56,6 +56,10 @@ def main():
         try:
             out = transcribe(infile)
             print(json.dumps(out, ensure_ascii=False))
+            try:
+                os.remove(infile)
+            except OSError:
+                pass
             return
         except Exception as e:
             last_err = str(e)


### PR DESCRIPTION
## Summary
- Delete input WAV inside `stt.py` after successful transcription
- Clarify deletion policy in `index.js` and remove redundant WAV cleanup in Node

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d6216e1c832c964f060a156b0b06